### PR TITLE
ESDK-1370 Use client-api version 0.0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
 	runtime "de.abas.homedir:jcl-over-slf4j:1.0.0"
 	runtime "de.abas.homedir:slf4j-api:1.0.0"
 
-	licensing "de.abas.esdk:client-api:0.0.7:all"
+	licensing "de.abas.esdk:client-api:0.0.11:all"
 
 	testImplementation "junit:junit:4.12"
 	testImplementation "org.hamcrest:hamcrest-all:1.3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # Accessing container via ssh: docker exec -u erp -it erp bash
     #
     erp:
-      image: sdp.registry.abas.sh/abas/test:2017r4n16
+      image: sdp.registry.abas.sh/abas/test:2017r4n16p02
       container_name: "erp"
 
       ports:


### PR DESCRIPTION
Use erp test image 2017r4n16p02 since in 2017r4n16 the license is expired.